### PR TITLE
Changed from using Gate to Owin.Types

### DIFF
--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -32,9 +32,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Gate">
-      <HintPath>..\#packages\Gate.0.27\lib\net40\Gate.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.Client">
       <HintPath>..\#packages\Microsoft.AspNet.SignalR.Client.1.1.0\lib\net45\Microsoft.AspNet.SignalR.Client.dll</HintPath>
     </Reference>
@@ -49,6 +46,9 @@
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\#packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin.Types">
+      <HintPath>..\#packages\Owin.Types.0.8.5\lib\net40\Owin.Types.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -77,7 +77,9 @@
     <Compile Include="SignalRTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Main\Main.csproj">

--- a/IntegrationTests/Internal/TestHost.cs
+++ b/IntegrationTests/Internal/TestHost.cs
@@ -6,7 +6,7 @@ namespace Gate.Adapters.AspNet.IntegrationTests.Internal {
         public const string TestApplicationDataValue = "Magic";
         public const string TestApplicationDataProviderValue = "Mirror";
 
-        private static readonly Uri _url = new Uri("http://localhost:8087");
+        private static readonly Uri _url = new Uri("http://localhost:60880");
 
         // causes static constructor to run
         public static Uri Url {

--- a/IntegrationTests/Internal/TestHostStartup.cs
+++ b/IntegrationTests/Internal/TestHostStartup.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Owin;
 
@@ -8,7 +9,7 @@ namespace Gate.Adapters.AspNet.IntegrationTests.Internal {
             var assembly = System.Reflection.Assembly.GetExecutingAssembly();
             //CodeBase references where the assembly originally was stored. Location pointed to somewhere Temp
             var webSitePath = Path.Combine(Path.GetDirectoryName(assembly.CodeBase), @"..\..\..\TestWebSite");
-            webSitePath = Path.GetFullPath(webSitePath);
+            webSitePath = Path.GetFullPath(new Uri(webSitePath).LocalPath);
 
             var testApplicationData = new Dictionary<string, object> {
                 { "Test.Data", TestHost.TestApplicationDataValue },

--- a/IntegrationTests/Internal/TestHostStartup.cs
+++ b/IntegrationTests/Internal/TestHostStartup.cs
@@ -5,7 +5,9 @@ using Owin;
 namespace Gate.Adapters.AspNet.IntegrationTests.Internal {
     public class TestHostStartup {
         public void Configuration(IAppBuilder app) {
-            var webSitePath = Path.Combine(Path.GetDirectoryName(this.GetType().Assembly.Location), @"..\..\..\TestWebSite");
+            var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+            //CodeBase references where the assembly originally was stored. Location pointed to somewhere Temp
+            var webSitePath = Path.Combine(Path.GetDirectoryName(assembly.CodeBase), @"..\..\..\TestWebSite");
             webSitePath = Path.GetFullPath(webSitePath);
 
             var testApplicationData = new Dictionary<string, object> {

--- a/IntegrationTests/packages.config
+++ b/IntegrationTests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Gate" version="0.27" targetFramework="net45" />
   <package id="Microsoft.AspNet.SignalR.Client" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="0.21.0-pre" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="0.21.0-pre" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="Owin.Types" version="0.8.5" targetFramework="net45" />
   <package id="xunit" version="1.9.1" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.1" targetFramework="net45" />
 </packages>

--- a/Main/Main.csproj
+++ b/Main/Main.csproj
@@ -36,8 +36,8 @@
     <Reference Include="Argument">
       <HintPath>..\#packages\Argument.0.9.6\lib\net45\Argument.dll</HintPath>
     </Reference>
-    <Reference Include="Gate">
-      <HintPath>..\#packages\Gate.0.27\lib\net40\Gate.dll</HintPath>
+    <Reference Include="Owin.Types">
+      <HintPath>..\#packages\Owin.Types.0.8.5\lib\net40\Owin.Types.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Main/packages.config
+++ b/Main/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Argument" version="0.9.6" targetFramework="net45" />
-  <package id="Gate" version="0.27" targetFramework="net45" />
+  <package id="Owin.Types" version="0.8.5" targetFramework="net45" />
 </packages>

--- a/TestConsoleHost/Program.cs
+++ b/TestConsoleHost/Program.cs
@@ -19,7 +19,7 @@ namespace Gate.Adapters.AspNet.TestConsoleHost {
         }
 
         private static void MainThatCanThrow() {
-            var url = "http://localhost:60880";
+            var url = "http://localhost:60880/";
 
             Console.WriteLine("Starting server at {0}.", url);
             using (WebApplication.Start<Startup>(url)) {


### PR DESCRIPTION
I have tried moving this library to the newer Owin.Types from https://github.com/owin/owin-hosting

The integration tests have been run, and as you can see there are some changes to them.

I have some doubts about Main/Integration/CrossAppDomainDataConverter.cs:19 where Version is changed to Protocol. I'm a bit new to Owin.

Any comment and corrections are more than welcome - thanks in advance.
